### PR TITLE
ci: bump runner type to `ubuntu-24.04`


### DIFF
--- a/.github/workflows/deps-automerge.yml
+++ b/.github/workflows/deps-automerge.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   automerge:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'loozhengyuan' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           # Enable them only if they are strictly required.
           # - "windows-2022"
           # - "macos-14"
-          - "ubuntu-22.04"
+          - "ubuntu-24.04"
         go:
           - "1.21"
           - "1.22"


### PR DESCRIPTION
This commit updates the repositories to use `ubuntu-24.04` runner type.