### PR TITLE
ci: bump to ubuntu-24.04

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -56,8 +56,8 @@ rulesets:
           required_status_checks:
             # NOTE: The Integration ID for GitHub Actions is `15368`
             - integration_id: 15368
-              context: test (ubuntu-22.04, 1.21)
+              context: test (ubuntu-24.04, 1.21)
             - integration_id: 15368
-              context: test (ubuntu-22.04, 1.22)
+              context: test (ubuntu-24.04, 1.22)
             - integration_id: 15368
-              context: test (ubuntu-22.04, 1.23)
+              context: test (ubuntu-24.04, 1.23)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           # Enable them only if they are strictly required.
           # - "windows-2022"
           # - "macos-14"
-          - "ubuntu-22.04"
+          - "ubuntu-24.04"
         go:
           - "1.21"
           - "1.22"


### PR DESCRIPTION
This commit updates the repositories to use `ubuntu-24.04` runner type.

Idempotency-Key: b65e24792f1426145cd7e87ec4b34af8f1f8997b122f0173c1f5dc88a97e9c97
